### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,0 +1,18 @@
+- name: front.messages
+  referenceId: PLACEHOLDER
+  description: SonarQube scan for front.messages
+  build:
+    provider: dkcicd
+    pipelines:
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: front.messages
+          nodeVersion: 20-bookworm
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: master


### PR DESCRIPTION
## Summary
- Creates `.vtex/deployment.yaml` with a `node-ci-v2` pipeline for SonarQube static code analysis
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. This repo has no unit tests, so SonarQube will provide static analysis only.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears